### PR TITLE
Use relative / URL instead of site.url

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="{{ site.url }}">{{ site.title }}</a>
+      <a class="navbar-brand" href="/">{{ site.title }}</a>
     </div>
 
     <div class="collapse navbar-collapse" id="main-navbar">
@@ -38,7 +38,7 @@
 	{% if site.avatar %}
 	<div class="avatar-container">
 	  <div class="avatar-img-border">
-	    <a href="{{ site.url }} ">
+	    <a href="/">
 	      <img class="avatar-img" src="{{ site.avatar | prepend: site.baseurl | replace: '//', '/' }}" />
 		</a>
 	  </div>


### PR DESCRIPTION
Currently the website running on jsxgraph.org has invalid links on both `JSXGraph` link in the navbar and the logo (they point to 0.0.0.0:4000). This is probably due to misconfiguration when building the website. In this PR I don't only report it, but also suggest an option to avoid the necessity to use site URL from the configuration.